### PR TITLE
Added file danta wrapper and lines wrapper. Now we are able to find line.

### DIFF
--- a/content/app/commands/goto-line-command.js
+++ b/content/app/commands/goto-line-command.js
@@ -86,9 +86,41 @@ define("content/app/commands/goto-line-command", function(require, exports, modu
 		 * @param  {Number} lineNumber
 		 */
 		_gotoLine : function (lineNumber) {
+			var line = this._findLine(lineNumber);
+			if (lineNumber) {
+				// TODO: Scroll to this location and highlight it somehow
+				alert("Goto line: " + lineNumber + " -> closest line: " + line.newNumber);
+				this._triggerComplete();
+			} else {
+				this._triggerCancel();
+			}
+		},
+
+		/**
+		 * Find closest line to specified line.
+		 * @param  {Number} 			lineNumber
+		 * @return {LineElementWrapper}
+		 */
+		_findLine : function (lineNumber) {
+			var line = null;
+
 			var currentFile = CommitPageHelper.getCurrentFile();
-			alert("Goto line: " + lineNumber + " in file: " + currentFile);
-			this._triggerComplete();
+			if (currentFile) {
+				var fileData = currentFile.getFileData();
+				var lines = fileData.getLines();
+				// TODO: Discuss about this!
+				// Currenlty this will return closest line by new line number.
+				lines.sort(function (line1, line2) {
+					var number1 = isNaN(line1.newNumber) ? Number.MAX_VALUE : line1.newNumber;
+					var number2 = isNaN(line2.newNumber) ? Number.MAX_VALUE : line2.newNumber;
+					var distance1 = Math.abs(lineNumber - number1);
+					var distance2 = Math.abs(lineNumber - number2);
+					return distance1 - distance2;
+				});
+				line = lines[0];
+			}
+
+			return line;
 		},
 
 		/**

--- a/content/app/github/commit-page-helper.js
+++ b/content/app/github/commit-page-helper.js
@@ -15,14 +15,7 @@ define("content/app/github/commit-page-helper", function(require, exports, modul
 			 * @return {FileElementWrapper[]}
 			 */
 			getAllFiles : function () {
-				var domElements = document.getElementsByClassName(FileElementWrapper.FILE_CLASS);
-
-				var files = [];
-				for (var i = 0; i < domElements.length; i++) {
-					files.push(new FileElementWrapper(domElements[i]));
-				}
-
-				return files;
+				return FileElementWrapper.getAllFromElement(document);
 			},
 
 			/**

--- a/content/app/github/wrappers/file-data-element-wrapper.js
+++ b/content/app/github/wrappers/file-data-element-wrapper.js
@@ -1,0 +1,54 @@
+define("content/app/github/wrappers/file-data-element-wrapper", function(require, exports, module) {
+
+	// imports
+	var DomElementWrapper = require("content/app/github/wrappers/dom-element-wrapper");
+	var LineElementWrapper = require("content/app/github/wrappers/line-element-wrapper");
+
+	/**
+	 * Wrapper for file data DOM element.
+	 */
+	var FileDataElementWrapper = Class(DomElementWrapper, {
+
+		$statics : {
+
+			CLASS_NAME : 'data',
+
+			/**
+			 * Get wrapper for file data DOM element form root.
+			 * @param  {Element} 					rootElement
+			 * @return {FileDataElementWrapper}
+			 */
+			getFromElement : function (rootElement) {
+				var domElements = rootElement.getElementsByClassName(FileDataElementWrapper.CLASS_NAME);
+
+				var fileData = null;
+				if (domElements.length > 0) {
+					fileData = new FileDataElementWrapper(domElements[0]);
+				}
+
+				return fileData;
+			},
+
+		},
+
+		/**
+		 * Constructor.
+		 * @param  {Element} domElement
+		 */
+		constructor : function (domElement) {
+			FileDataElementWrapper.$super.call(this, domElement);
+		},
+
+		/**
+		 * Get all lines wrappers from this data.
+		 * @return {LineElementWrapper[]}
+		 */
+		getLines : function () {
+			return LineElementWrapper.getAllFromElement(this._domElement);
+		},
+
+	});
+
+	module.exports = FileDataElementWrapper;
+
+});

--- a/content/app/github/wrappers/file-element-wrapper.js
+++ b/content/app/github/wrappers/file-element-wrapper.js
@@ -2,6 +2,7 @@ define("content/app/github/wrappers/file-element-wrapper", function(require, exp
 
 	// imports
 	var DomElementWrapper = require("content/app/github/wrappers/dom-element-wrapper");
+	var FileDataElementWrapper = require("content/app/github/wrappers/file-data-element-wrapper");
 
 	/**
 	 * Wrapper for file DOM element.
@@ -10,7 +11,23 @@ define("content/app/github/wrappers/file-element-wrapper", function(require, exp
 
 		$statics : {
 
-			FILE_CLASS : 'file',
+			CLASS_NAME : 'file',
+
+			/**
+			 * Fet all wrappers for all elements in root.
+			 * @param  {Element} 				rootElement
+			 * @return {FileElementWrapper[]}
+			 */
+			getAllFromElement : function (rootElement) {
+				var domElements = rootElement.getElementsByClassName(FileElementWrapper.CLASS_NAME);
+
+				var files = [];
+				for (var i = 0; i < domElements.length; i++) {
+					files.push(new FileElementWrapper(domElements[i]));
+				}
+
+				return files;
+			}
 
 		},
 
@@ -20,6 +37,14 @@ define("content/app/github/wrappers/file-element-wrapper", function(require, exp
 		 */
 		constructor : function (domElement) {
 			FileElementWrapper.$super.call(this, domElement);
+		},
+
+		/**
+		 * Get file data element wrapper for current file.
+		 * @return {FileDataElementWrapper}
+		 */
+		getFileData : function () {
+			return FileDataElementWrapper.getFromElement(this._domElement);
 		},
 
 	});

--- a/content/app/github/wrappers/line-element-wrapper.js
+++ b/content/app/github/wrappers/line-element-wrapper.js
@@ -1,0 +1,96 @@
+define("content/app/github/wrappers/line-element-wrapper", function(require, exports, module) {
+
+	// imports
+	var DomElementWrapper = require("content/app/github/wrappers/dom-element-wrapper");
+
+	/**
+	 * Wrapper for line DOM element.
+	 */
+	var LineElementWrapper = Class(DomElementWrapper, {
+
+		$statics : {
+
+			TAG_NAME : 'tr',
+			NUMBER_ATTR_NAME : 'data-line-number',
+
+			/**
+			 * Get wrappers for all DOM elements in root.
+			 * @param  {Element} 			rootElement
+			 * @return {LineElementWrapper}
+			 */
+			getAllFromElement : function (rootElement) {
+				var domElements = rootElement.getElementsByTagName(LineElementWrapper.TAG_NAME);
+
+				var lines = [];
+				for (var i = 0; i < domElements.length; i++) {
+					var domElement = domElements[i];
+					// TODO: Consider additional filtering.
+					lines.push(new LineElementWrapper(domElement));
+				}
+
+				return lines;
+			},
+
+		},
+
+		/**
+		 * Constructor.
+		 * @param  {Element} domElement
+		 */
+		constructor : function (domElement) {
+			LineElementWrapper.$super.call(this, domElement);
+			this._oldNumber = null;
+			this._newNumber = null;
+			this._proccessElement();
+		},
+
+		/**
+		 * Get old code line.
+		 * @type {Number}
+		 */
+		oldNumber : {
+			get : function () {
+				return this._oldNumber;
+			},
+		},
+
+		/**
+		 * Get new code number.
+		 * @type {Number}
+		 */
+		newNumber : {
+			get : function () {
+				return this._newNumber;
+			},
+		},
+
+		/**
+		 * Process element content to set wrapper state.
+		 */
+		_proccessElement : function () {
+			var children = this._domElement.children;
+			this._oldNumber = this._extractLineNumber(children[0]);
+			this._newNumber = this._extractLineNumber(children[1]);
+		},
+
+		/**
+		 * Extract line number from DOM element.
+		 * @param  {Element} domElement
+		 * @return {Number}
+		 */
+		_extractLineNumber : function (domElement) {
+			var lineNumber = null;
+
+			if (domElement && domElement.attributes.hasOwnProperty(LineElementWrapper.NUMBER_ATTR_NAME)) {
+				var attr = domElement.attributes[LineElementWrapper.NUMBER_ATTR_NAME];
+				lineNumber = parseInt(attr.value);
+			}
+
+			return lineNumber;
+		},
+
+	});
+
+	module.exports = LineElementWrapper;
+
+});

--- a/manifest.json
+++ b/manifest.json
@@ -82,6 +82,8 @@
 
         "content/app/github/window-helper.js",
         "content/app/github/wrappers/dom-element-wrapper.js",
+        "content/app/github/wrappers/line-element-wrapper.js",
+        "content/app/github/wrappers/file-data-element-wrapper.js",
         "content/app/github/wrappers/file-element-wrapper.js",
         "content/app/github/commit-page-helper.js",
 


### PR DESCRIPTION
@zikicm please take a look.
- Getting elements and making wrappers are moved to wrappers static methods as that is more natural place for them. Beside that when content structure changes we'll need to change only one file.
- Added file content (data) wrapper.
- Added line wrapper that currently supports old and new line number.

I've added 2 TODOs in code. We'll need to discuss:
- Scrolling and highlighting, but this is not priority as I don't have much info about this right now.
- What line number (old or new) is more interesting to user, or do we want to make hybrid or to use some keyword from input (for example "old@123" for using old number and just "123" for using new). Or we want to wait for users to tell us what they want.
- How do we want to handle if line number is hidden and you need to click to view that line (like in file-element.wrapper.js in this pull req if you want to see line 9). Do we want to navigate to closest number as it is in current implementation or we want to set focus on button for showing more code... I more prefer 2nd approach.
